### PR TITLE
auto find other modules for exes

### DIFF
--- a/auto-expose-example-project/src/exampleBenchmark/Main.hs
+++ b/auto-expose-example-project/src/exampleBenchmark/Main.hs
@@ -1,4 +1,6 @@
 module Main where
 
+import Module (message)
+
 main :: IO ()
-main = print "example benchmark"
+main = print message

--- a/auto-expose-example-project/src/exampleBenchmark/Module.hs
+++ b/auto-expose-example-project/src/exampleBenchmark/Module.hs
@@ -1,0 +1,4 @@
+module Module where
+
+message :: String
+message = "example benchmark"

--- a/auto-expose-example-project/src/exampleExe/Main.hs
+++ b/auto-expose-example-project/src/exampleExe/Main.hs
@@ -1,4 +1,6 @@
 module Main where
 
+import Module (message)
+
 main :: IO ()
-main = print "example executable"
+main = print message

--- a/auto-expose-example-project/src/exampleExe/Module.hs
+++ b/auto-expose-example-project/src/exampleExe/Module.hs
@@ -1,0 +1,4 @@
+module Module where
+
+message :: String
+message = "example executable"

--- a/auto-expose-example-project/src/exampleTestSuite/Main.hs
+++ b/auto-expose-example-project/src/exampleTestSuite/Main.hs
@@ -1,4 +1,6 @@
 module Main where
 
+import Module (message)
+
 main :: IO ()
-main = print "example test suite"
+main = print message

--- a/auto-expose-example-project/src/exampleTestSuite/Module.hs
+++ b/auto-expose-example-project/src/exampleTestSuite/Module.hs
@@ -1,0 +1,4 @@
+module Module where
+
+message :: String
+message = "example test suite"

--- a/cabal-auto-expose/cabal-auto-expose.cabal
+++ b/cabal-auto-expose/cabal-auto-expose.cabal
@@ -47,12 +47,12 @@ test-suite cabal-auto-expose-tests
     filepath,
     QuickCheck >= 2.14.1 && < 2.15
 
-benchmark cabal-auto-expose-benchmarks
-  type: exitcode-stdio-1.0
-  main-is: Benchmark.hs
-  build-depends:
-    base >= 4.14 && < 4.15,
-    QuickCheck >= 2.14.1 && < 2.15,
-    criterion >= 1.5.7.0 && < 1.5.8.0,
-    cabal-auto-expose,
-    time >= 1.11 && < 1.12
+-- benchmark cabal-auto-expose-benchmarks
+--  type: exitcode-stdio-1.0
+--  main-is: Benchmark.hs
+--  build-depends:
+--    base >= 4.14 && < 4.15,
+--    QuickCheck >= 2.14.1 && < 2.15,
+--    criterion >= 1.5.7.0 && < 1.5.8.0,
+--    cabal-auto-expose,
+--    time >= 1.11 && < 1.12

--- a/cabal-auto-expose/cabal-auto-expose.cabal
+++ b/cabal-auto-expose/cabal-auto-expose.cabal
@@ -30,7 +30,7 @@ library
   ghc-options: -Wall
   build-depends:
     Cabal >= 3.2.0.0 && < 3.5.0.0,
-    base >= 4.14 && < 4.15,
+    base >= 4.13 && < 4.15,
     filepath,
     directory,
     extra >= 1.7.7 && < 1.8
@@ -40,7 +40,7 @@ test-suite cabal-auto-expose-tests
   main-is: Test.hs
   other-modules: Paths_cabal_auto_expose
   build-depends:
-    base >= 4.14 && < 4.15,
+    base >= 4.13 && < 4.15,
     Cabal >= 3.2.0.0 && < 3.5.0.0,
     cabal-auto-expose == 0.1.0.2,
     hspec >= 2.7.4 && < 2.8,
@@ -51,7 +51,7 @@ benchmark cabal-auto-expose-benchmarks
   type: exitcode-stdio-1.0
   main-is: Benchmark.hs
   build-depends:
-    base >= 4.14 && < 4.15,
+    base >= 4.13 && < 4.15,
     QuickCheck >= 2.14.1 && < 2.15,
     criterion >= 1.5.7.0 && < 1.5.10.0,
     cabal-auto-expose,

--- a/cabal-auto-expose/cabal-auto-expose.cabal
+++ b/cabal-auto-expose/cabal-auto-expose.cabal
@@ -47,12 +47,12 @@ test-suite cabal-auto-expose-tests
     filepath,
     QuickCheck >= 2.14.1 && < 2.15
 
--- benchmark cabal-auto-expose-benchmarks
---  type: exitcode-stdio-1.0
---  main-is: Benchmark.hs
---  build-depends:
---    base >= 4.14 && < 4.15,
---    QuickCheck >= 2.14.1 && < 2.15,
---    criterion >= 1.5.7.0 && < 1.5.8.0,
---    cabal-auto-expose,
---    time >= 1.11 && < 1.12
+benchmark cabal-auto-expose-benchmarks
+  type: exitcode-stdio-1.0
+  main-is: Benchmark.hs
+  build-depends:
+    base >= 4.14 && < 4.15,
+    QuickCheck >= 2.14.1 && < 2.15,
+    criterion >= 1.5.7.0 && < 1.5.8.0,
+    cabal-auto-expose,
+    time >= 1.10 && < 1.12

--- a/cabal-auto-expose/cabal-auto-expose.cabal
+++ b/cabal-auto-expose/cabal-auto-expose.cabal
@@ -53,6 +53,6 @@ benchmark cabal-auto-expose-benchmarks
   build-depends:
     base >= 4.14 && < 4.15,
     QuickCheck >= 2.14.1 && < 2.15,
-    criterion >= 1.5.7.0 && < 1.5.8.0,
+    criterion >= 1.5.7.0 && < 1.5.10.0,
     cabal-auto-expose,
     time >= 1.9 && < 1.12

--- a/cabal-auto-expose/cabal-auto-expose.cabal
+++ b/cabal-auto-expose/cabal-auto-expose.cabal
@@ -55,4 +55,4 @@ benchmark cabal-auto-expose-benchmarks
     QuickCheck >= 2.14.1 && < 2.15,
     criterion >= 1.5.7.0 && < 1.5.8.0,
     cabal-auto-expose,
-    time >= 1.10 && < 1.12
+    time >= 1.9 && < 1.12


### PR DESCRIPTION
Prior to this, even with `cabal-auto-expose`, you still have to specify `other-modules` for executables. This makes it so that isn't needed :partying_face: 

I'm not 100% sure this is correct in all cases. I tried to follow existing patterns as much as possible. Let me know if there is something that looks broken.

I'm going to add support for tests as well.